### PR TITLE
Correct certificate CN extraction

### DIFF
--- a/jqm-all/jqm-ws/src/main/java/com/enioka/jqm/webui/shiro/CertificateToken.java
+++ b/jqm-all/jqm-ws/src/main/java/com/enioka/jqm/webui/shiro/CertificateToken.java
@@ -15,9 +15,15 @@
  */
 package com.enioka.jqm.webui.shiro;
 
-import java.security.cert.X509Certificate;
-
 import org.apache.shiro.authc.AuthenticationToken;
+import org.bouncycastle.asn1.x500.RDN;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.asn1.x500.style.IETFUtils;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
+
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
 
 public class CertificateToken implements AuthenticationToken
 {
@@ -38,7 +44,13 @@ public class CertificateToken implements AuthenticationToken
 
     public String getUserName()
     {
-        return clientCert.getSubjectDN().getName().replaceFirst("CN=", "");
+        try {
+            X500Name x500name = new JcaX509CertificateHolder(clientCert).getSubject();
+            RDN cn = x500name.getRDNs(BCStyle.CN)[0];
+            return IETFUtils.valueToString(cn.getFirst().getValue());
+        } catch (CertificateEncodingException e) {
+            return "";
+        }
     }
 
     @Override


### PR DESCRIPTION
Contains the following changes:
- Added correct method of CN extraction (otherwise certificates wit organizational entries or other attributes lead to authentication failure)
- Added logoutput to detect certificate issues

To be checked:
- Loglevel appropriate/consistent with project?

Why:
When setting up the certificate authentication in our project I was struggling getting it to work with an external PKI. Took a look into the code to figure out. This should definitely not be necessary.
Also the previous implementation was based on string replacement and assumed that the client certificate only contained a CN unfortunately there was no mention of this in the documentation.