### PR TITLE
Optimize DB.getConnection

### DIFF
--- a/jqm-all/jqm-model/src/main/java/com/enioka/jqm/jdbc/Db.java
+++ b/jqm-all/jqm-model/src/main/java/com/enioka/jqm/jdbc/Db.java
@@ -437,9 +437,15 @@ public class Db
         try
         {
             Connection cnx = _ds.getConnection();
-            cnx.setAutoCommit(false);
-            cnx.rollback(); // To ensure no open transaction created by the pool before changing TX mode
-            cnx.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+            if (cnx.getAutoCommit()) {
+                cnx.setAutoCommit(false);
+                cnx.rollback(); // To ensure no open transaction created by the pool before changing TX mode
+            }
+
+            if (cnx.getTransactionIsolation() != Connection.TRANSACTION_READ_COMMITTED) {
+                cnx.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+            }
+
             return new DbConn(this, cnx);
         }
         catch (SQLException e)


### PR DESCRIPTION
After profiling I detect that DB.getConnection take a long time. It's because  setAutoCommit, rollback and setTransactionIsolation methods are complex in mysql driver. I added some checks, to optimize and set this flags only on demand. Also, it's little bit strange, because it seems that this flags can be configured on connection-pool level. What do you think about it?

https://tomcat.apache.org/tomcat-7.0-doc/jdbc-pool.html
see dbcp properties:
defaultAutoCommit
defaultTransactionIsolation