### PR TITLE
Make node network interface to listen on customizable at the time of creation

### DIFF
--- a/jqm-all/jqm-engine/src/main/java/com/enioka/jqm/tools/Helpers.java
+++ b/jqm-all/jqm-engine/src/main/java/com/enioka/jqm/tools/Helpers.java
@@ -303,10 +303,14 @@ final class Helpers
      * 
      * @param nodeName
      *            name of the node that should be created or updated (if incompletely defined only)
-     * @param em
-     *            an EntityManager on which a transaction will be opened.
+     * @param cnx
+     *            an DbConn on which a transaction will be opened.
+     * @param port
+     *            port for a node to listen on
+     * @param dns
+     *            network interface (dns) for a node to listen on (localhost by default)
      */
-    static void updateNodeConfiguration(String nodeName, DbConn cnx, int port)
+    static void updateNodeConfiguration(String nodeName, DbConn cnx, int port, String dns)
     {
         // Node
         Integer nodeId = null;
@@ -319,7 +323,7 @@ final class Helpers
             jqmlogger.info("Node " + nodeName + " does not exist in the configuration and will be created with default values");
 
             nodeId = Node.create(cnx, nodeName, port, System.getProperty("user.dir") + "/jobs/", System.getProperty("user.dir") + "/jobs/",
-                    System.getProperty("user.dir") + "/tmp/", "localhost", "INFO").getId();
+                    System.getProperty("user.dir") + "/tmp/", dns, "INFO").getId();
             cnx.commit();
         }
 

--- a/jqm-all/jqm-model/src/main/java/com/enioka/jqm/jdbc/DbImplBase.java
+++ b/jqm-all/jqm-model/src/main/java/com/enioka/jqm/jdbc/DbImplBase.java
@@ -28,8 +28,8 @@ class DbImplBase
                 + "VALUES(JQM_PK.nextval, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
         queries.put("node_delete_all", "DELETE FROM __T__NODE");
         queries.put("node_delete_by_id", "DELETE __T__NODE WHERE ID=?");
-        queries.put("node_update_all_enable_ws", "UPDATE __T__NODE SET LOAD_API_SIMPLE=true, LOAD_API_CLIENT=true, LOAD_API_ADMIN=true, DNS='0.0.0.0'");
-        queries.put("node_update_enable_ws_by_id", "UPDATE __T__NODE SET LOAD_API_SIMPLE=true, LOAD_API_CLIENT=true, LOAD_API_ADMIN=true, DNS='0.0.0.0' WHERE ID=?");
+        queries.put("node_update_all_enable_ws", "UPDATE __T__NODE SET LOAD_API_SIMPLE=true, LOAD_API_CLIENT=true, LOAD_API_ADMIN=true");
+        queries.put("node_update_enable_ws_by_id", "UPDATE __T__NODE SET LOAD_API_SIMPLE=true, LOAD_API_CLIENT=true, LOAD_API_ADMIN=true WHERE ID=?");
         queries.put("node_update_all_disable_ws", "UPDATE __T__NODE SET LOAD_API_CLIENT=false, LOAD_API_ADMIN=false");
         queries.put("node_update_all_disable_all_ws", "UPDATE __T__NODE SET LOAD_API_SIMPLE=false, LOAD_API_CLIENT=false, LOAD_API_ADMIN=false");
         queries.put("node_update_enabled_by_id", "UPDATE __T__NODE SET ENABLED=? WHERE ID=?");

--- a/jqm-all/jqm-service/src/main/java/com/enioka/jqm/tools/Main.java
+++ b/jqm-all/jqm-service/src/main/java/com/enioka/jqm/tools/Main.java
@@ -174,8 +174,10 @@ public class Main
         options.addOptionGroup(og2);
         OptionGroup og3 = new OptionGroup();
         og3.addOption(o62);
-        og3.addOption(o63);
         options.addOptionGroup(og3);
+        OptionGroup og4 = new OptionGroup();
+        og4.addOption(o63);
+        options.addOptionGroup(og4);
 
         HelpFormatter formatter = new HelpFormatter();
         formatter.setWidth(160);


### PR DESCRIPTION
A couple modifications in a context of #334 

1.  Removed implicit binding of a node to 0.0.0.0 while enabling UI and Web Services
2. Made default dns=localhost and added "-dns" parameter support for CLI in order to customize network interface while creating a node (if different from localhost is required)

@marcanpilami I've provided adjustments based on #334 Please review them and merge if they fit your plans with regard to that point