### PR TITLE
Remove unnecessary `-X POST` in curl examples

### DIFF
--- a/jqm-all/jqm-doc/src/site/sphinx/jobs_shell/api.rst
+++ b/jqm-all/jqm-doc/src/site/sphinx/jobs_shell/api.rst
@@ -18,7 +18,7 @@ The account is garanteed to stay valid at least 24 hours and should not be used 
 
 For example, a bash script may use this command to request the execution of a child job::
 
-  curl --user "${JQM_API_LOGIN}:${JQM_API_PASSWORD}" --url "${JQM_API_LOCAL_URL}/ws/simple/ji" -XPOST -d "applicationname=ChildAppName&parentid=${JQM_JI_ID}" -H "Content-Type: application/x-www-form-urlencoded" 
+  curl --user "${JQM_API_LOGIN}:${JQM_API_PASSWORD}" --url "${JQM_API_LOCAL_URL}/ws/simple/ji" -d "applicationname=ChildAppName&parentid=${JQM_JI_ID}" -H "Content-Type: application/x-www-form-urlencoded" 
 
 
 Creating temp files

--- a/jqm-all/jqm-integration-tests/src/test/java/com/enioka/jqm/tools/ShellRunnerTest.java
+++ b/jqm-all/jqm-integration-tests/src/test/java/com/enioka/jqm/tools/ShellRunnerTest.java
@@ -201,7 +201,7 @@ public class ShellRunnerTest extends JqmBaseTest
             CreationTools.createJobDef("test job 2", true, "none", new HashMap<>(), "echo 'aa'", TestHelpers.qNormal, 0, "TestApp2", null,
                     "module1", "kw1", "kw2", null, false, cnx, null, false, null, false, PathType.DEFAULTSHELLCOMMAND);
 
-            String script = "curl --user \"${JQM_API_LOGIN}:${JQM_API_PASSWORD}\" --url \"${JQM_API_LOCAL_URL}/ws/simple/ji\" -XPOST -d \"applicationname=TestApp2&parentid=${JQM_JI_ID}\" -H 'Content-Type: application/x-www-form-urlencoded' -s ";
+            String script = "curl --user \"${JQM_API_LOGIN}:${JQM_API_PASSWORD}\" --url \"${JQM_API_LOCAL_URL}/ws/simple/ji\" -d \"applicationname=TestApp2&parentid=${JQM_JI_ID}\" -H 'Content-Type: application/x-www-form-urlencoded' -s ";
 
             CreationTools.createJobDef("test job", true, "none", new HashMap<>(), script, TestHelpers.qNormal, 0, "TestApp1", null,
                     "module1", "kw1", "kw2", null, false, cnx, null, false, null, false, PathType.DEFAULTSHELLCOMMAND);


### PR DESCRIPTION
`curl -d` already tells `curl` to use the POST http method

cf. https://daniel.haxx.se/blog/2015/09/11/unnecessary-use-of-curl-x/